### PR TITLE
[v1.2.x] revert an upstream commit that breaks minizip on linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,13 @@ source:
   git_rev: 8658af7e0a73d6ac4d94e81dde0e9fa95b1aff47
   patches:
     - patches/0001-set-separate-suffix-for-static-builds-on-windows.patch
+    # undo an upstream commit that switches too aggressively to
+    # arc4random_buf, which is not available on linux, see:
+    # https://github.com/zlib-ng/minizip-ng/commit/dac37702b3fab4068ac9a7c4a992df7f0e4f14df
+    - patches/0002-Revert-Use-arc4random_buf.-Issue-175.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: minizip

--- a/recipe/patches/0001-set-separate-suffix-for-static-builds-on-windows.patch
+++ b/recipe/patches/0001-set-separate-suffix-for-static-builds-on-windows.patch
@@ -1,7 +1,7 @@
 From eed16c969d6549fa8217071d0d6f9f8d96579fe3 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 12:09:44 +1100
-Subject: [PATCH] set separate suffix for static builds on windows
+Subject: [PATCH 1/2] set separate suffix for static builds on windows
 
 ---
  CMakeLists.txt | 3 +++

--- a/recipe/patches/0002-Revert-Use-arc4random_buf.-Issue-175.patch
+++ b/recipe/patches/0002-Revert-Use-arc4random_buf.-Issue-175.patch
@@ -1,0 +1,67 @@
+From 6862419419a244bb1bb7f4ed0f14844269e1e5f1 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Thu, 5 Oct 2023 08:54:41 +1100
+Subject: [PATCH 2/2] Revert "Use arc4random_buf. (Issue: #175)"
+
+This reverts commit dac37702b3fab4068ac9a7c4a992df7f0e4f14df.
+---
+ crypt.c | 27 ++++++++++++++++++++++-----
+ 1 file changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/crypt.c b/crypt.c
+index a074b8f..6c519d0 100644
+--- a/crypt.c
++++ b/crypt.c
+@@ -46,6 +46,10 @@
+ 
+ #define CRC32(c, b) ((*(pcrc_32_tab+(((uint32_t)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))
+ 
++#ifndef ZCR_SEED2
++#  define ZCR_SEED2 3141592654UL     /* use PI as default pattern */
++#endif
++
+ /***************************************************************************/
+ 
+ uint8_t decrypt_byte(uint32_t *pkeys)
+@@ -87,10 +91,11 @@ void init_keys(const char *passwd, uint32_t *pkeys, const z_crc_t *pcrc_32_tab)
+ #ifndef NOCRYPT
+ int cryptrand(unsigned char *buf, unsigned int len)
+ {
++    static unsigned calls = 0;
++    int rlen = 0;
+ #ifdef _WIN32
+     HCRYPTPROV provider;
+     unsigned __int64 pentium_tsc[1];
+-    int rlen = 0;
+     int result = 0;
+ 
+ 
+@@ -108,12 +113,24 @@ int cryptrand(unsigned char *buf, unsigned int len)
+             QueryPerformanceCounter((LARGE_INTEGER *)pentium_tsc);
+         buf[rlen] = ((unsigned char*)pentium_tsc)[rlen % 8];
+     }
+-
+-    return rlen;
+ #else
+-    arc4random_buf(buf, len);
+-    return len;
++    int frand = open("/dev/urandom", O_RDONLY);
++    if (frand != -1)
++    {
++        rlen = (int)read(frand, buf, len);
++        close(frand);
++    }
+ #endif
++    if (rlen < (int)len)
++    {
++        /* Ensure different random header each time */
++        if (++calls == 1)
++            srand((unsigned)(time(NULL) ^ ZCR_SEED2));
++
++        while (rlen < (int)len)
++            buf[rlen++] = (rand() >> 7) & 0xff;
++    }
++    return rlen;
+ }
+ 
+ int crypthead(const char *passwd, uint8_t *buf, int buf_size, uint32_t *pkeys,


### PR DESCRIPTION
Fix the linux failures observed in https://github.com/conda-forge/libkml-feedstock/pull/25
```
symbol lookup error: $SRC_DIR/build/lib/libkmlbase.so.1: undefined symbol: arc4random_buf
```

Minizip past 2.0 has changed a lot (no more `crypt.c`), so it's hard to backport something. The newest minizip has some elaborate [fallbacks](https://github.com/zlib-ng/minizip-ng/blob/4.0.1/mz_os_posix.c#L121) for whether `arc4random_buf` is present (needs CMake detection to set up symbols etc.), but for now the simplest is just to revert the commit that broke this.

Reverts https://github.com/zlib-ng/minizip-ng/commit/dac37702b3fab4068ac9a7c4a992df7f0e4f14df