### PR TITLE
fix windows lib,dll name

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -21,3 +21,11 @@ cmake --install .
 if %ERRORLEVEL% neq 0 exit 1
 
 cd ..
+
+rem rename the lib/dll to libminizip
+copy %LIBRARY_BIN%\minizip.dll %LIBRARY_BIN%\libminizip.dll
+del %LIBRARY_BIN%\minizip.dll
+if %ERRORLEVEL% neq 0 exit 1
+copy %LIBRARY_LIB%\minizip.lib %LIBRARY_LIB%\libminizip.lib
+del %LIBRARY_LIB%\minizip.lib
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a87f1f734f97095fe1ef0018217c149d53d0f78438bcb77af38adc21dff2dfbc
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('minizip', max_pin='x') }}
 
@@ -35,8 +35,8 @@ test:
   commands:
     # presence of shared libraries
     - test -f $PREFIX/lib/libminizip${SHLIB_EXT}        # [unix]
-    - if not exist %LIBRARY_BIN%\minizip.dll exit 1  # [win]
-    - if not exist %LIBRARY_LIB%\minizip.lib exit 1  # [win]
+    - if not exist %LIBRARY_BIN%\libminizip.dll exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\libminizip.lib exit 1  # [win]
 
     # absence of static libraries
     - test ! -f $PREFIX/lib/libminizip.a                # [unix]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

@conda-forge-admin please rerender
fixes #19
restores windows dll,lib file names prior to 4.0.7